### PR TITLE
Fixed bug saving time like "00:12"

### DIFF
--- a/TimeTracking/pages/add_record.php
+++ b/TimeTracking/pages/add_record.php
@@ -40,6 +40,7 @@
    # Work on Time-Entry so we can eval it
    $t_time_value = plugin_TimeTracking_hhmm_to_minutes($f_time_value);
    $t_time_value = doubleval($t_time_value / 60);
+   $t_time_value = str_replace(',', '.', $t_time_value);
 
    # Trigger in case of non-evaluable entry
    if ( $t_time_value == 0 ) {


### PR DESCRIPTION
Fix a bug that prevents save value of minuts on database.

Before fix:
Value like "00:12" save as "00:00".
Value like "1:34" save as "01:00".