### PR TITLE
Patch for db_minutes_to_hhmm

### DIFF
--- a/TimeTracking/TimeTracking.php
+++ b/TimeTracking/TimeTracking.php
@@ -19,6 +19,7 @@
    2005 by Elmar Schumacher - GAMBIT Consulting GmbH
    http://www.mantisbt.org/forums/viewtopic.php?f=4&t=589
 */
+require_once( 'core/timetracking_api.php' ); 
 class TimeTrackingPlugin extends MantisPlugin {
 
 	function register() {
@@ -188,7 +189,7 @@ class TimeTrackingPlugin extends MantisPlugin {
    <tr>
       <td class="small-caption"><?php echo user_get_name($t_row["user"]); ?></td>
       <td class="small-caption"><?php echo date( config_get("short_date_format"), strtotime($t_row["expenditure_date"])); ?> </td>
-      <td class="small-caption"><?php echo db_minutes_to_hhmm($t_row["hours"] * 60) ?> </td>
+      <td class="small-caption"><?php echo plugin_TimeTracking_hours_to_hhmm($t_row["hours"]) ?> </td>
       <td class="small-caption"><?php echo string_display_links($t_row["category"]); ?></td>
       <td class="small-caption"><?php echo string_display_links($t_row["info"]); ?></td>
       <td class="small-caption"><?php echo date( config_get("complete_date_format"), strtotime($t_row["timestamp"])); ?> </td>
@@ -224,7 +225,7 @@ class TimeTrackingPlugin extends MantisPlugin {
    <tr class="row-category">
       <td class="small-caption"><?php echo plugin_lang_get( 'sum' ) ?></td>
       <td class="small-caption">&nbsp;</td>
-      <td class="small-caption"><div align="right"><b><?php echo db_minutes_to_hhmm($t_row_pull_hours['hours']* 60); ?></b></div></td>
+      <td class="small-caption"><div align="right"><b><?php echo plugin_TimeTracking_hours_to_hhmm( $t_row_pull_hours['hours'] ); ?></b></div></td>
       <td class="small-caption">&nbsp;</td>
       <td class="small-caption">&nbsp;</td>
       <td class="small-caption">&nbsp;</td>

--- a/TimeTracking/core/timetracking_api.php
+++ b/TimeTracking/core/timetracking_api.php
@@ -62,15 +62,24 @@ function plugin_TimeTracking_stats_get_project_array( $p_project_id, $p_from, $p
 }
 
 /**
-* Returns an array of time tracking stats
-* @param int $p_project_id project id
-* @param string $p_from Starting date (yyyy-mm-dd) inclusive, if blank, then ignored.
-* @param string $p_to Ending date (yyyy-mm-dd) inclusive, if blank, then ignored.
-* @return array array of bugnote stats
+* Returns an integer of minutes
+* @param string $p_hhmm Time (hh:mm)
+* @return integer integer of minutes
 * @access public
 */
 function plugin_TimeTracking_hhmm_to_minutes( $p_hhmm) {
 	sscanf($p_hhmm, "%d:%d", $hours, $minutes); 
 	return $hours * 60 + $minutes;
+}
+
+/**
+* convert hours to a time format [h]h:mm
+* @param string $p_hhmm Time (hh:mm)
+* @return integer integer of minutes
+* @access public
+*/
+function plugin_TimeTracking_hours_to_hhmm( $p_hours ) {
+	$t_min = round( $p_hours * 60 );
+	return sprintf( '%02d:%02d', $t_min / 60, $t_min % 60 );
 }
 ?>

--- a/TimeTracking/pages/show_report.php
+++ b/TimeTracking/pages/show_report.php
@@ -162,7 +162,7 @@ if ( !is_blank( $f_plugin_TimeTracking_stats_button ) ) {
 			<?php echo $t_item['category'] ?>
 			</td>
 			<td class="small-caption">
-			<?php echo number_format($t_item['hours'], 2, '.', ',') ?>
+			<?php echo number_format($t_item['hours'], 2, '.', ',') ?> (<?php echo plugin_TimeTracking_hours_to_hhmm( $t_item['hours'] ); ?>)
 			</td>
 			<td class="small-caption">
 			<?php echo $t_item['info'] ?>
@@ -176,7 +176,7 @@ if ( !is_blank( $f_plugin_TimeTracking_stats_button ) ) {
 			<?php echo lang_get( 'total_time' ); ?>
 			</td>
 			<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td class="small-caption">
-			<?php echo number_format($t_sum_in_hours, 2, '.', ','); ?> (<?php echo db_minutes_to_hhmm( $t_sum_in_hours * 60); ?>)
+			<?php echo number_format($t_sum_in_hours, 2, '.', ','); ?> (<?php echo plugin_TimeTracking_hours_to_hhmm( $t_sum_in_hours ); ?>)
 			</td><td>&nbsp;</td>
 			</tr>
 			</tfoot>
@@ -221,7 +221,7 @@ if ( !is_blank( $f_plugin_TimeTracking_stats_button ) ) {
 			<?php echo lang_get( 'total_time' ); ?>(<?php echo $t_user_key; ?>)
 			</td>
 			<td class="small-caption">
-			<?php echo number_format($t_user_value, 2, '.', ','); ?> (<?php echo db_minutes_to_hhmm( $t_user_value * 60); ?>)
+			<?php echo number_format($t_user_value, 2, '.', ','); ?> (<?php echo plugin_TimeTracking_hours_to_hhmm( $t_user_value ); ?>)
 			</td>
 			</tr>
 			<?php } ?>
@@ -267,7 +267,7 @@ if ( !is_blank( $f_plugin_TimeTracking_stats_button ) ) {
 			<?php echo $t_project_key; ?>
 			</td>
 			<td class="small-caption">
-			<?php echo number_format($t_project_value, 2, '.', ','); ?> (<?php echo db_minutes_to_hhmm( $t_project_value * 60); ?>)
+			<?php echo number_format($t_project_value, 2, '.', ','); ?> (<?php echo plugin_TimeTracking_hours_to_hhmm( $t_project_value ); ?>)
 			</td>
 			</tr>
 			<?php } ?>
@@ -312,7 +312,7 @@ if ( !is_blank( $f_plugin_TimeTracking_stats_button ) ) {
 			<?php echo bug_format_id( $t_bug_key ); ?>
 			</td>
 			<td class="small-caption">
-			<?php echo number_format($t_bug_value, 2, '.', ','); ?> (<?php echo db_minutes_to_hhmm( $t_bug_value * 60); ?>)
+			<?php echo number_format($t_bug_value, 2, '.', ','); ?> (<?php echo plugin_TimeTracking_hours_to_hhmm( $t_bug_value ); ?>)
 			</td>
 			</tr>
 			<?php } ?>


### PR DESCRIPTION
New function plugin_TimeTracking_hours_to_hhmm to replace
db_minutes_to_hhmm which doesn't handle floating point numbers